### PR TITLE
feat: 메인 페이지 hikingTrails api 추가

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -8,13 +8,13 @@ interface Props {
   level: string;
   km: number;
   like: number;
-  img: string | null;
+  img?: string | null;
 }
 
 const Card = ({ title, location, level, km, like, img }: Props) => {
   return (
     <CardWrapper>
-      <img src={img !== null ? img : '/images/Rectangle33.png'} width="100%" />
+      <img src={img ? img : '/images/Rectangle33.png'} width="100%" />
       <ContentWrapper>
         <Title>
           {title}

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -8,12 +8,13 @@ interface Props {
   level: string;
   km: number;
   like: number;
+  img: string | null;
 }
 
-const Card = ({ title, location, level, km, like }: Props) => {
+const Card = ({ title, location, level, km, like, img }: Props) => {
   return (
     <CardWrapper>
-      <img src="/images/Rectangle33.png" width="100%" />
+      <img src={img !== null ? img : '/images/Rectangle33.png'} width="100%" />
       <ContentWrapper>
         <Title>
           {title}

--- a/components/mylogs/tab.tsx
+++ b/components/mylogs/tab.tsx
@@ -1,0 +1,36 @@
+import { Breadcrumb } from 'antd';
+import type { Route } from 'antd/lib/breadcrumb/Breadcrumb';
+import styled from 'styled-components';
+
+import { ReactComponent as ListIcon } from '../../assets/svgs/hikingList.svg';
+import { ReactComponent as MountainIcon } from '../../assets/svgs/mountain.svg';
+import { ReactComponent as CameraIcon } from '../../assets/svgs/mylogCamera.svg';
+import NavLink from '../navlink';
+
+const routes: Route[] = [
+  { path: '/mylogs', breadcrumbName: '인덱스' },
+  { path: '/mylogs?tab=row', breadcrumbName: '로우' },
+  { path: '/mylogs?tab=col', breadcrumbName: '컬럼' },
+];
+
+const icons = [<MountainIcon />, <CameraIcon />, <ListIcon />];
+
+const Tab = () => {
+  return <StyledTab routes={routes} itemRender={TabItem} />;
+};
+
+const TabItem = (route: Route, _: any, __: Route[], paths: string[]) => {
+  return (
+    <NavLink href={route.path}>
+      <h1>{route.breadcrumbName}</h1>
+    </NavLink>
+  );
+};
+
+export default Tab;
+
+const StyledTab = styled(Breadcrumb)`
+  position: absolute;
+  li:nth-child(odd) {
+  }
+`;

--- a/constants/queries.ts
+++ b/constants/queries.ts
@@ -1,5 +1,6 @@
 enum QueryKeys {
   WEATHER_KEY = 'WEATHER',
+  HIKING_TRAILS_QUERY_KEY = 'HIKING_TRAILS_QUERY',
 }
 
 export default QueryKeys;

--- a/hooks/queries/useHikingTrailsQuery.ts
+++ b/hooks/queries/useHikingTrailsQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import QueryKeys from '~/constants/queries';
+import { ResponseHikingTrails } from '~/types/hikingTrails';
+
+export default function useHikingTrailsQuery(query: string, options?: {}) {
+  return useQuery<ResponseHikingTrails, Error>(
+    [QueryKeys.HIKING_TRAILS_QUERY_KEY],
+    () =>
+      fetch(
+        `${process.env.NEXT_PUBLIC_URL}/server/api/hiking-trails${query}`
+      ).then((res) => res.json()),
+    options
+  );
+}

--- a/types/hikingTrails.ts
+++ b/types/hikingTrails.ts
@@ -1,0 +1,16 @@
+interface HikingTrails {
+  id: number;
+  imageUrl: null | string;
+  name: string;
+  address: string;
+  favoriteCount: number;
+  difficulty: 'EASY' | 'NORMAL' | 'HARD';
+  length: number;
+}
+
+interface ResponseHikingTrails {
+  contents: HikingTrails[];
+  hasNext: boolean;
+}
+
+export type { HikingTrails, ResponseHikingTrails };

--- a/utils/misc.ts
+++ b/utils/misc.ts
@@ -2,6 +2,10 @@ type ErrorWithMessage = {
   message: string;
 };
 
+interface Queries {
+  [key: string]: number | string;
+}
+
 function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
   return (
     typeof error === 'object' &&
@@ -36,6 +40,14 @@ const misc = {
     return value;
   },
   getErrorMessage,
+  makeQueries: (queries: Queries) => {
+    return Object.entries(queries)
+      .map(([key, value], idx) => {
+        if (idx === 0) return `?${key}=${value}`;
+        return `&${key}=${value}`;
+      })
+      .join('');
+  },
 };
 
 export default misc;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/home/api -> dev

### 변경 사항

tanstack-query를 사용해서 프리페칭을 사용했습니다.

이후 재사용에 용이하도록 misc 파일에 query 유틸 함수를 만들어두었습니다!

card 쪽 hikingTrails 데이터에 맞게 조금 수정했습니다

타입도 hikingTrails 추가해두었는데 네이밍과 구조를 한번 봐주시면 좋을거같습니다 ^ㅡ^

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="943" alt="스크린샷 2022-09-07 오후 11 39 18" src="https://user-images.githubusercontent.com/66871265/188906358-9630f12a-3577-4c4e-bb06-99a1e0131818.png">

아직 레이아웃이 안잡혀있죠? ㅋㅋㅋㅋ 스타일은 이후 추가하도록 하겠습니다..

### Issue

#61 

