### PR TITLE
feat: add withAuthSsr HOF

### DIFF
--- a/components/globalStyle.ts
+++ b/components/globalStyle.ts
@@ -46,6 +46,7 @@ const GlobalStyle = createGlobalStyle`
 
   html, body {
     font-family: 'Pretendard';
+    height: 100%;
   }
 
   body {

--- a/components/typography.tsx
+++ b/components/typography.tsx
@@ -22,6 +22,7 @@ interface TypographyProps extends PropsWithChildren {
   size?: FontSize;
   weight?: FontWeight;
   color?: FontColor;
+  lineHeight?: string;
   as?: React.ElementType;
 }
 
@@ -29,6 +30,7 @@ const Typography = ({
   className,
   as = 'p',
   color = 'black',
+  lineHeight = '1.563rem',
   ...props
 }: TypographyProps): React.ReactElement => {
   return (
@@ -51,6 +53,6 @@ const BaseTypography = styled.p<TypographyProps>`
     font-weight: ${props.weight && FONT_WEIGHT[props.weight]};
     color: ${contants.colors[props.color || 'black']};
     white-space: pre-wrap;
-    line-height: 1.563rem;
+    line-height: ${props.lineHeight};
   `}
 `;

--- a/hof/withAuthSsr.ts
+++ b/hof/withAuthSsr.ts
@@ -1,0 +1,57 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import type { Session } from 'next-auth';
+import { getSession } from 'next-auth/react';
+
+export function withAuthSsr<
+  P extends { [key: string]: unknown } = { [key: string]: unknown }
+>(
+  handler: (
+    context: GetServerSidePropsContext & { req: { session?: Session } }
+  ) => GetServerSidePropsResult<P> | Promise<GetServerSidePropsResult<P>>,
+  redirect?: string
+) {
+  return async (context: GetServerSidePropsContext) => {
+    const session = await getSession(context);
+
+    if (session) {
+      Object.defineProperty(
+        context.req,
+        'session',
+        getPropertyDescriptorForReqSession(session)
+      );
+    } else if (redirect) {
+      return {
+        redirect: {
+          destination: redirect,
+          statusCode: 302,
+        },
+      } as GetServerSidePropsResult<P>;
+    }
+    return handler(context);
+  };
+}
+
+function getPropertyDescriptorForReqSession(
+  session: Session
+): PropertyDescriptor {
+  return {
+    enumerable: true,
+    get() {
+      return session;
+    },
+    set(value) {
+      const keys = Object.keys(value);
+      const currentKeys = Object.keys(session);
+
+      currentKeys.forEach((key) => {
+        if (!keys.includes(key)) {
+          delete session[key];
+        }
+      });
+
+      keys.forEach((key) => {
+        session[key] = value[key];
+      });
+    },
+  };
+}

--- a/pages/auth/redirect.tsx
+++ b/pages/auth/redirect.tsx
@@ -2,13 +2,10 @@ import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
 
-import Button from './button';
+import Button from '~/components/button';
+import Typography from '~/components/typography';
 
-interface Props {
-  content: string;
-}
-
-const Protected = ({ content }: Props) => {
+const Protected = () => {
   return (
     <Base>
       <Outline>
@@ -18,7 +15,9 @@ const Protected = ({ content }: Props) => {
           width={200}
           height={158}
         />
-        <Paragraph>{content}</Paragraph>
+        <Typography size="r4" weight="regular">
+          로그인하고 나만의 등산로그를 기록해보세요!
+        </Typography>
       </Outline>
       <Link href="/auth/signIn">
         <Button>로그인/회원가입</Button>
@@ -43,10 +42,7 @@ const Outline = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-`;
-
-const Paragraph = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.r4};
-  font-weight: 400;
-  padding-top: 1rem;
+  p {
+    padding-top: 1rem;
+  }
 `;

--- a/pages/mylogs/index.tsx
+++ b/pages/mylogs/index.tsx
@@ -1,5 +1,5 @@
+import { withAuthSsr } from 'hof/withAuthSsr';
 import { useRouter } from 'next/router';
-import { signOut, useSession } from 'next-auth/react';
 import type { ReactElement } from 'react';
 import styled from 'styled-components';
 
@@ -7,16 +7,10 @@ import Divider from '~/components/divider';
 import Layout from '~/components/layout';
 import Tab from '~/components/mylogs/tab';
 import Toggle from '~/components/mylogs/toggle';
-import Protected from '~/components/protected';
 import type { NextPageWithLayout } from '~/types/base';
 
 const Mylogs: NextPageWithLayout<{}> = () => {
-  const { data: session, status } = useSession();
   const { query } = useRouter();
-
-  if (status === 'unauthenticated') {
-    return <Protected content="로그인하고 나만의 등산로그를 기록해보세요!" />;
-  }
 
   if (query?.tab === 'wrap') {
     return (
@@ -39,7 +33,6 @@ const Mylogs: NextPageWithLayout<{}> = () => {
   return (
     <>
       <h1>my logs</h1>
-      <button onClick={() => signOut()}>로그아웃</button>
     </>
   );
 };
@@ -57,6 +50,14 @@ Mylogs.getLayout = function (page: ReactElement) {
 };
 
 export default Mylogs;
+
+export const getServerSideProps = withAuthSsr(({ req }) => {
+  return {
+    props: {
+      user: req.session,
+    },
+  };
+}, '/auth/redirect');
 
 const MyLogsBase = styled.main`
   position: relative;

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -1,4 +1,5 @@
-import { useSession } from 'next-auth/react';
+import { withAuthSsr } from 'hof/withAuthSsr';
+import { InferGetServerSidePropsType } from 'next/types';
 import type { ReactElement } from 'react';
 import styled from 'styled-components';
 
@@ -6,19 +7,14 @@ import Divider from '~/components/divider';
 import Layout from '~/components/layout';
 import MyImage from '~/components/profile/myImage';
 import ProfileNavlink from '~/components/profile/profileNavlink';
-import Protected from '~/components/protected';
 import type { NextPageWithLayout } from '~/types/base';
 
-const Profile: NextPageWithLayout<{}> = () => {
-  const { data: session, status } = useSession();
-
-  if (status === 'unauthenticated') {
-    return <Protected content="로그인하고 나만의 등산로그를 기록해보세요!" />;
-  }
-
+const Profile: NextPageWithLayout<
+  InferGetServerSidePropsType<typeof getServerSideProps>
+> = ({ user }) => {
   return (
     <Base>
-      <MyImage>{session?.user?.email}</MyImage>
+      <MyImage>{user?.user.email}</MyImage>
       <Divider margin="0" dense="8" color="#F3F4F4" />
       <ProfileNavlink />
     </Base>
@@ -30,5 +26,13 @@ Profile.getLayout = function getLayout(page: ReactElement) {
 };
 
 export default Profile;
+
+export const getServerSideProps = withAuthSsr(({ req }) => {
+  return {
+    props: {
+      user: req.session,
+    },
+  };
+}, '/auth/redirect');
 
 const Base = styled.main``;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/hof

### 변경 사항

SSR이 필요한 페이지에서,
HOF를 통해 서버 단에서 사용자의 로그인 여부를 체크하고 /auth/redirect 페이지로 리다이렉트 시키는 로직을 만들어 재사용성을 추가했습니다.

```jsx
export const getServerSideProps = withAuthSsr(({ req }) => {
  return {
    props: {
      user: req.session,
    },
  };
}, 'here is redirect url');
```

기존의 protected 컴포넌트를 삭제처리하고 /auth/redirect 페이지를 추가하여 이쪽으로 리다이렉트 시키고 있습니다!


### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### Issue

resolved: #77 

