### PR TITLE
fix: sign in error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
     "import/no-named-as-default": "off",
     "@typescript-eslint/ban-types": "off",
     "o@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "off"
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-var-requires": "off"
   }
 }

--- a/components/auth/styled.ts
+++ b/components/auth/styled.ts
@@ -48,8 +48,8 @@ const AuthForm = styled(Form)`
   line-height: inherit;
 `;
 
-const AuthFormItem = styled(Form.Item)<{ full?: boolean }>`
-  width: ${({ full }) => full && '100%'};
+const AuthFormItem = styled(Form.Item)<{ $full?: boolean }>`
+  width: ${({ $full }) => $full && '100%'};
   margin-bottom: 0;
   .ant-input-affix-wrapper:focus,
   .ant-input-affix-wrapper-focused {

--- a/pages/auth/signIn.tsx
+++ b/pages/auth/signIn.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
-import { ReactElement, useEffect } from 'react';
+import { ReactElement } from 'react';
 import styled from 'styled-components';
 
 import AuthLabel from '~/components/auth/authLabel';
@@ -24,7 +24,7 @@ interface FormData {
 }
 
 const SignIn = () => {
-  const { isPending, success, error, handleSubmit } = useForm<FormData>({
+  const { isPending, handleSubmit } = useForm<FormData>({
     serviceCallback: async (values) =>
       signIn('credentials', {
         email: values.email,
@@ -32,13 +32,10 @@ const SignIn = () => {
       }),
   });
 
-  useEffect(() => {
-    console.log('pending', isPending);
-  }, [isPending]);
   return (
     <>
       <AuthBase root>
-        <ParagraphOutline>
+        <section>
           <Image
             src="/images/01_Logotype.png"
             alt="logo.png"
@@ -46,7 +43,7 @@ const SignIn = () => {
             height={25}
           />
           <Paragraph>{'로그인하고\n나만의 등산로그를 기록해보세요!'}</Paragraph>
-        </ParagraphOutline>
+        </section>
       </AuthBase>
       <AuthForm onFinish={(v) => handleSubmit(v as FormData)}>
         <AuthBase>
@@ -73,14 +70,15 @@ const SignIn = () => {
                   placeholder="비밀번호를 입력해주세요."
                   type="password"
                   name="password"
+                  autoComplete="off"
                 />
               </AuthFormItem>
             </AuthLabel>
           </AuthInputOutline>
-          <LinkOutline right>
+          <LinkOutline $right>
             <Link href="/">비밀번호를 잊으셨나요?</Link>
           </LinkOutline>
-          <AuthFormItem full>
+          <AuthFormItem $full>
             <Button type="submit">{isPending ? '진행중...' : '로그인'}</Button>
           </AuthFormItem>
           <LinkOutline>
@@ -114,16 +112,13 @@ SignIn.getLayout = function getLayout(page: ReactElement) {
 
 export default SignIn;
 
-const ParagraphOutline = styled.section``;
-
-const LinkOutline = styled.div<{ right?: boolean }>`
+const LinkOutline = styled.div<{ $right?: boolean }>`
   width: 100%;
   display: flex;
-  justify-content: ${({ right }) => (right ? 'flex-end' : 'center')};
-  padding-bottom: ${({ right }) => right && '1rem'};
+  justify-content: ${({ $right }) => ($right ? 'flex-end' : 'center')};
+  padding-bottom: ${({ $right }) => $right && '1rem'};
   font-size: ${({ theme }) => theme.fontSize.r2};
   padding-top: 0.7rem;
-  font-weight: 400;
   color: ${({ theme }) => theme.colors.gray_medium};
 `;
 

--- a/pages/auth/signUp.tsx
+++ b/pages/auth/signUp.tsx
@@ -146,7 +146,7 @@ const SignUp = () => {
           <AuthFormItem
             name="SERVICE"
             valuePropName="checked"
-            full
+            $full
             rules={[
               {
                 validator: validator.service,

--- a/pages/auth/signUp.tsx
+++ b/pages/auth/signUp.tsx
@@ -180,7 +180,7 @@ const SignUp = () => {
       </AuthBase>
       <Divider />
       <AuthBase>
-        <AuthFormItem full>
+        <AuthFormItem $full>
           <Button type="submit">{isPending ? '진행중...' : '회원가입'}</Button>
         </AuthFormItem>
       </AuthBase>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/83/signInError -> dev

### 변경 사항
<img width="527" alt="error" src="https://user-images.githubusercontent.com/77133565/191697894-21e8a70f-43b8-409d-866f-738ad409bc09.png">
<img width="527" alt="styled-components" src="https://user-images.githubusercontent.com/77133565/191697898-7bf5562e-7876-4eb8-8a89-1efb5ba5b195.png">

애러와 경고를 제거했습니다.

- styled-components 사용시 prefix를 $로 주어야지 DOM 이슈를 해결할 수 있습니다.

- input password에서 autocomplete 속성을 false값을 주어야 웹에서 경고를 보내지 않습니다.

- eslint가 적용되지 않은 경고가 있어 예외처리를 해주었습니다.
"@typescript-eslint/no-var-requires": "off"

- 지워지지않은 console.log를 제거했습니다.


### 테스트 결과

![image](https://user-images.githubusercontent.com/77133565/191698345-3b31a7ec-1b96-441c-aa4d-d955eb57c570.png)


### Issue

resolved: #83 

