### PR TITLE
fix: 날씨예보 배너 Api 에러

### DIFF
--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -24,7 +24,7 @@ const Banner = () => {
     staleTime: 5000,
     cacheTime: Infinity,
     suspense: true,
-  }) as { data: Weather };
+  }) as unknown as { data: Weather };
 
   return (
     <Base>
@@ -53,8 +53,6 @@ const Banner = () => {
           height={115}
           src={weatherData?.weatherImg}
           alt={weatherData?.weatherImg}
-          blurDataURL={weatherData.weatherBase64}
-          placeholder="blur"
         />
       </WeatherImagePositionBox>
       <PositionBox>
@@ -64,8 +62,6 @@ const Banner = () => {
           height={200}
           src={weatherData?.landingImg}
           alt={weatherData?.landingImg}
-          blurDataURL={weatherData.landingBase64}
-          placeholder="blur"
         />
       </PositionBox>
     </Base>

--- a/components/home/title.tsx
+++ b/components/home/title.tsx
@@ -17,8 +17,8 @@ const Title = ({ image, base64, arrow, children }: Props) => {
       <Image
         src={image}
         alt={image}
-        width={24}
-        height={29}
+        width={28}
+        height={28}
         placeholder={base64 ? 'blur' : undefined}
         blurDataURL={base64 ? base64 : undefined}
       />

--- a/hooks/queries/useWeather.ts
+++ b/hooks/queries/useWeather.ts
@@ -5,9 +5,7 @@ import QueryKeys from '~/constants/queries';
 interface Weather {
   content: string;
   landingImg: string;
-  landingBase64: string;
   weatherImg: string;
-  weatherBase64: string;
   city: string;
 }
 

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -18,7 +18,6 @@ export default async function handler(
   const { nx, ny } = mapService.mapToGrid(latitude, longitude);
   const url = misc.env('NEXT_PUBLIC_WEATHER_END_POINT');
   const apiKey = misc.env('NEXT_PUBLIC_WEATHER_API_KEY');
-  console.log('check env', url, apiKey);
 
   const _res = await fetch(
     `${url}?serviceKey=${apiKey}&numOfRows=10&pageNo=1&base_date=${baseDate}&base_time=${
@@ -28,7 +27,7 @@ export default async function handler(
 
   if (!_res.ok)
     return res
-      .status(500)
+      .status(502)
       .json({ message: '날씨예보 Api 불러오기에 실패했습니다.' });
 
   const data = await _res.json();
@@ -44,7 +43,7 @@ export default async function handler(
 
   if (!weather)
     return res
-      .status(502)
+      .status(500)
       .json({ message: '날씨예보 로직에서 문제가 발생했습니다.' });
 
   const { base64: landingBase64 } = await getPlaiceholder(weather.landingImg);

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -33,7 +33,7 @@ export default async function handler(
   const data = await _res.json();
 
   if (data.response.header.resultCode !== '00')
-    return res.status(500).json({
+    return res.status(501).json({
       message: data.response.header.resultMsg,
     });
 
@@ -43,7 +43,7 @@ export default async function handler(
 
   if (!weather)
     return res
-      .status(500)
+      .status(502)
       .json({ message: '날씨예보 로직에서 문제가 발생했습니다.' });
 
   const { base64: landingBase64 } = await getPlaiceholder(weather.landingImg);

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -18,6 +18,7 @@ export default async function handler(
   const { nx, ny } = mapService.mapToGrid(latitude, longitude);
   const url = misc.env('NEXT_PUBLIC_WEATHER_END_POINT');
   const apiKey = misc.env('NEXT_PUBLIC_WEATHER_API_KEY');
+  console.log('check env', url, apiKey);
 
   const _res = await fetch(
     `${url}?serviceKey=${apiKey}&numOfRows=10&pageNo=1&base_date=${baseDate}&base_time=${

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -1,5 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { getPlaiceholder } from 'plaiceholder';
 
 import * as mapService from '~/utils/map';
 import * as misc from '~/utils/misc';
@@ -46,13 +45,8 @@ export default async function handler(
       .status(500)
       .json({ message: '날씨예보 로직에서 문제가 발생했습니다.' });
 
-  const { base64: landingBase64 } = await getPlaiceholder(weather.landingImg);
-  const { base64: weatherBase64 } = await getPlaiceholder(weather.weatherImg);
-
   const withBase64 = {
     ...weather,
-    landingBase64,
-    weatherBase64,
   };
 
   return res.status(200).json({

--- a/pages/api/weather.ts
+++ b/pages/api/weather.ts
@@ -14,33 +14,49 @@ export default async function handler(
     longitude: string;
     city: string;
   };
-
+  const [baseDate, baseHour] = weatherService.getBaseTime();
   const { nx, ny } = mapService.mapToGrid(latitude, longitude);
+  const url = misc.env('NEXT_PUBLIC_WEATHER_END_POINT');
+  const apiKey = misc.env('NEXT_PUBLIC_WEATHER_API_KEY');
 
-  try {
-    const weather = await weatherService.getWeather({
-      url: misc.env('NEXT_PUBLIC_WEATHER_END_POINT'),
-      apiKey: misc.env('NEXT_PUBLIC_WEATHER_API_KEY'),
-      nx,
-      ny,
+  const _res = await fetch(
+    `${url}?serviceKey=${apiKey}&numOfRows=10&pageNo=1&base_date=${baseDate}&base_time=${
+      baseHour + '00'
+    }&nx=${nx}&ny=${ny}&dataType=JSON`
+  );
+
+  if (!_res.ok)
+    return res
+      .status(500)
+      .json({ message: '날씨예보 Api 불러오기에 실패했습니다.' });
+
+  const data = await _res.json();
+
+  if (data.response.header.resultCode !== '00')
+    return res.status(500).json({
+      message: data.response.header.resultMsg,
     });
 
-    if (!weather) throw new Error('invalid api');
+  const weather = weatherService.getPtyOrSkyOfItems(
+    data.response.body.items.item
+  );
 
-    const { base64: landingBase64 } = await getPlaiceholder(weather.landingImg);
-    const { base64: weatherBase64 } = await getPlaiceholder(weather.weatherImg);
+  if (!weather)
+    return res
+      .status(500)
+      .json({ message: '날씨예보 로직에서 문제가 발생했습니다.' });
 
-    const withBase64 = {
-      ...weather,
-      landingBase64,
-      weatherBase64,
-    };
+  const { base64: landingBase64 } = await getPlaiceholder(weather.landingImg);
+  const { base64: weatherBase64 } = await getPlaiceholder(weather.weatherImg);
 
-    return res.json({
-      ...withBase64,
-      city,
-    });
-  } catch (error) {
-    throw new Error(misc.getErrorMessage(error));
-  }
+  const withBase64 = {
+    ...weather,
+    landingBase64,
+    weatherBase64,
+  };
+
+  return res.status(200).json({
+    ...withBase64,
+    city,
+  });
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,7 +81,7 @@ const Home: NextPageWithLayout<
       </Outline>
       <Divider />
       <Outline>
-        <Title image="/images/09_Mountain2.png">
+        <Title image="/images/10_Mountain3.png">
           등산이
           <Highlight> 처음</Highlight>이신가요?
         </Title>

--- a/utils/weather.ts
+++ b/utils/weather.ts
@@ -2,19 +2,10 @@ import dayjs from 'dayjs';
 
 import { PTY_CONTENTS, PTY_NULL_TYPE, SKY_CONTENTS } from '~/constants/weather';
 
-import * as misc from './misc';
-
 const isBaseTime = ['02', '05', '08', '11', '14', '17', '20', '23'];
 const isBaseTimePlus1Hour = ['03', '06', '09', '12', '15', '18', '21', '00'];
 const isBaseTimePlus2Hour = ['04', '07', '10', '13', '16', '19', '22', '01'];
 const isEdgeTime = ['23', '00', '01'];
-
-interface GetWeather {
-  url: string;
-  apiKey: string;
-  nx: number;
-  ny: number;
-}
 
 interface Item {
   baseDate: string;
@@ -57,26 +48,4 @@ const getPtyOrSkyOfItems = (items: Item[]) => {
   return PTY_CONTENTS[parseInt(getFcstValueOfUniqueItem(items, 'PTY'))];
 };
 
-export const getWeather = async ({ url, apiKey, nx, ny }: GetWeather) => {
-  const [baseDate, baseHour] = getBaseTime();
-
-  try {
-    const res = await fetch(
-      `${url}?serviceKey=${apiKey}&numOfRows=10&pageNo=1&base_date=${baseDate}&base_time=${
-        baseHour + '00'
-      }&nx=${nx}&ny=${ny}&dataType=JSON`
-    );
-
-    const data = await res.json();
-
-    if (data.response.header.resultCode !== '00') {
-      throw misc.getErrorMessage(data.response.header.resultMsg);
-    }
-
-    const weather = getPtyOrSkyOfItems(data.response.body.items.item);
-
-    return weather;
-  } catch (error) {
-    misc.getErrorMessage(error);
-  }
-};
+export { getBaseTime, getPtyOrSkyOfItems };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/banner -> dev

### 변경 사항

vercel에서 로그 체킹하느라 커밋 내역이 많네요..

처음 알게된 사실인데 yarn 2.x 버전대에서 서버리스 함수를 사용하는 경우 정적파일 접근이 안되더라구요?.. 

[공식문서 링크](https://vercel.com/guides/does-vercel-support-yarn-2)

그래서 날씨예보 로직에서 base64를 인코딩하는 plaiceholder 함수들을 삭제했습니다.
이전에 충일님이 plaiceholder 작업하는데 안됐던 이유가 이거였네요 ㅋㅋ 

yarn berry로 마이그레이션하면서 이전엔 되었던게 안되어서 생긴 이슈였습니다.

### Issue

resolved: #135 

